### PR TITLE
Handle null rating fields

### DIFF
--- a/src/main/java/com/cultureclub/cclub/service/EventoServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/EventoServiceImpl.java
@@ -44,6 +44,13 @@ public class EventoServiceImpl implements EventoService {
             Usuario organizador = usuarioService.getUsuarioById(idUsuario)
                     .orElseThrow(() -> new IllegalArgumentException("Organizador no encontrado"));
             evento.setUsuarioOrganizador(organizador);
+            // Initialize fields that can be null
+            if (evento.getCalificacion() == null) {
+                evento.setCalificacion(0);
+            }
+            if (evento.getCantidadVisitas() == null) {
+                evento.setCantidadVisitas(0);
+            }
             return eventoRepository.save(evento);
         }
     }

--- a/src/main/java/com/cultureclub/cclub/service/UsuarioServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/UsuarioServiceImpl.java
@@ -97,10 +97,23 @@ public class UsuarioServiceImpl implements UsuarioService {
         }
         Usuario usuario = usuarioOpt.get();
         Evento evento = eventoOpt.get();
-        Integer calificacionTotalActual = calificacion
-                + (evento.getCalificacion() * evento.getCantidadVisitas());
-        evento.setCantidadVisitas(evento.getCantidadVisitas() + 1);
-        double promedio = (double) calificacionTotalActual / evento.getCantidadVisitas();
+
+        // Initialize values to zero if they are null
+        if (evento.getCalificacion() == null) {
+            evento.setCalificacion(0);
+        }
+        if (evento.getCantidadVisitas() == null) {
+            evento.setCantidadVisitas(0);
+        }
+
+        int visitasActuales = evento.getCantidadVisitas();
+        int calificacionAcumulada = evento.getCalificacion() * visitasActuales;
+        int calificacionTotalActual = calificacion + calificacionAcumulada;
+
+        visitasActuales += 1;
+        double promedio = (double) calificacionTotalActual / visitasActuales;
+
+        evento.setCantidadVisitas(visitasActuales);
         evento.setCalificacion((int) Math.round(promedio));
         eventoRepository.save(evento);
         System.out


### PR DESCRIPTION
## Summary
- initialize `calificacion` and `cantidadVisitas` when creating events
- default those fields to zero before rating calculations

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a030b4f48324b8240cd4c7015289