### PR TITLE
Restrict updates to authenticated user

### DIFF
--- a/src/main/java/com/cultureclub/cclub/controller/EventoController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/EventoController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PutMapping;
 
 @RestController
 @RequestMapping("/eventos")
@@ -32,6 +33,15 @@ public class EventoController {
             throws Exception {
         EventoDTO evento = EventoMapper.toDTO(eventoService.createEvento(entity, idUsuario));
         return ResponseEntity.created(URI.create("/eventos/" + evento.getIdEvento())).body(evento);
+    }
+
+    @PutMapping("/{idUsuario}/{idEvento}")
+    public ResponseEntity<EventoDTO> actualizarEvento(
+            @RequestBody EventoDTO entity,
+            @PathVariable Long idUsuario,
+            @PathVariable Long idEvento) {
+        Evento evento = eventoService.updateEvento(idEvento, entity, idUsuario);
+        return ResponseEntity.ok(EventoMapper.toDTO(evento));
     }
 
     @GetMapping("")

--- a/src/main/java/com/cultureclub/cclub/security/SecurityConfig.java
+++ b/src/main/java/com/cultureclub/cclub/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .requestMatchers("/gestorUsuarios/**").hasRole("ADMIN")
                 .requestMatchers("/premium/**").hasAnyRole("ADMIN", "PREMIUM")
                 .requestMatchers("/usuarios/**").authenticated()
+                .requestMatchers("/eventos/**").authenticated()
                 .anyRequest().denyAll()
             )
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import com.cultureclub.cclub.entity.Evento;
@@ -13,6 +15,7 @@ import com.cultureclub.cclub.entity.Usuario;
 import com.cultureclub.cclub.entity.dto.EventoDTO;
 import com.cultureclub.cclub.entity.enumeradores.ClaseEvento;
 import com.cultureclub.cclub.repository.EventoRepository;
+import com.cultureclub.cclub.repository.UsuarioRepository;
 import com.cultureclub.cclub.service.Int.EventoService;
 import com.cultureclub.cclub.service.Int.GestorUsuarioService;
 
@@ -23,6 +26,18 @@ public class EventoServiceImpl implements EventoService {
     private EventoRepository eventoRepository;
     @Autowired
     private GestorUsuarioService usuarioService;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    private Usuario getAuthenticatedUsuario() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            throw new AccessDeniedException("Usuario no autenticado");
+        }
+        String email = auth.getName();
+        return usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new AccessDeniedException("Usuario no encontrado"));
+    }
 
     @Override
     public Page<Evento> getEventos(int page, int size) {
@@ -65,6 +80,38 @@ public class EventoServiceImpl implements EventoService {
         } else {
             throw new IllegalArgumentException("Evento no encontrado con ID: " + idEvento);
         }
+    }
+
+    @Override
+    public Evento updateEvento(Long idEvento, EventoDTO entity, Long idUsuario) {
+        Usuario authUser = getAuthenticatedUsuario();
+        if (!authUser.getIdUsuario().equals(idUsuario)) {
+            throw new AccessDeniedException("No autorizado para editar este evento");
+        }
+
+        Evento evento = eventoRepository.findById(idEvento)
+                .orElseThrow(() -> new IllegalArgumentException("Evento no encontrado con ID: " + idEvento));
+
+        if (!evento.getUsuarioOrganizador().getIdUsuario().equals(authUser.getIdUsuario())) {
+            throw new AccessDeniedException("No autorizado para editar este evento");
+        }
+
+        if (entity.getNombre() != null) {
+            evento.setNombre(entity.getNombre());
+        }
+        evento.setEntrada(entity.isEntrada());
+        evento.setPrecio(entity.getPrecio());
+        if (entity.getInicio() != null) {
+            evento.setInicio(entity.getInicio());
+        }
+        if (entity.getFin() != null) {
+            evento.setFin(entity.getFin());
+        }
+        if (entity.getClase() != null) {
+            evento.setClase(ClaseEvento.valueOf(entity.getClase()));
+        }
+
+        return eventoRepository.save(evento);
     }
 
     @Override

--- a/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
@@ -3,6 +3,8 @@ package com.cultureclub.cclub.service.Impl;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import com.cultureclub.cclub.entity.Ciudad;
@@ -44,6 +46,16 @@ public class UsuarioServiceImpl implements UsuarioService {
     @Autowired
     private EntradaRepository entradaRepository;
 
+    private Usuario getAuthenticatedUsuario() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            throw new AccessDeniedException("Usuario no autenticado");
+        }
+        String email = auth.getName();
+        return usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new AccessDeniedException("Usuario no encontrado"));
+    }
+
     @Override
     public Optional<Usuario> getUsuarioById(Long id) {
         return usuarioRepository.findById(id);
@@ -51,22 +63,27 @@ public class UsuarioServiceImpl implements UsuarioService {
 
     @Override
     public String updateUsuario(Long id, UsuarioDTO data) {
+        Usuario authUser = getAuthenticatedUsuario();
+        if (!authUser.getIdUsuario().equals(id)) {
+            throw new AccessDeniedException("No autorizado para editar otro usuario");
+        }
+
         Optional<Usuario> usuarioOpt = usuarioRepository.findById(id);
         if (usuarioOpt.isEmpty()) {
             throw new IllegalArgumentException("Usuario no encontrado con ID: " + id);
-        } else {
-            Usuario usuario = usuarioOpt.get();
-            usuario.setNombre(data.getNombre() != null ? data.getNombre() : usuario.getNombre());
-            usuario.setEmail(data.getEmail() != null ? data.getEmail() : usuario.getEmail());
-            usuario.setApellidos(data.getApellidos() != null ? data.getApellidos() : usuario.getApellidos());
-            usuario.setCiudad(data.getCiudad() != null ? Ciudad.valueOf(data.getCiudad()) : usuario.getCiudad());
-            usuario.setTelefono(data.getTelefono() != null ? data.getTelefono() : usuario.getTelefono());
-            usuario.setRoles(null != data.getRoles() ? data.getRoles() : usuario.getRoles());
-            usuario.setPassword(data.getPassword() != null ? data.getPassword() : usuario.getPassword());
-
-            usuarioRepository.save(usuario);
-            return "Usuario actualizado correctamente";
         }
+
+        Usuario usuario = usuarioOpt.get();
+        usuario.setNombre(data.getNombre() != null ? data.getNombre() : usuario.getNombre());
+        usuario.setEmail(data.getEmail() != null ? data.getEmail() : usuario.getEmail());
+        usuario.setApellidos(data.getApellidos() != null ? data.getApellidos() : usuario.getApellidos());
+        usuario.setCiudad(data.getCiudad() != null ? Ciudad.valueOf(data.getCiudad()) : usuario.getCiudad());
+        usuario.setTelefono(data.getTelefono() != null ? data.getTelefono() : usuario.getTelefono());
+        usuario.setRoles(null != data.getRoles() ? data.getRoles() : usuario.getRoles());
+        usuario.setPassword(data.getPassword() != null ? data.getPassword() : usuario.getPassword());
+
+        usuarioRepository.save(usuario);
+        return "Usuario actualizado correctamente";
     }
 
     @Override

--- a/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
@@ -13,6 +13,8 @@ public interface EventoService {
 
     public Evento getEventoById(Long idEvento);
 
+    public Evento updateEvento(Long idEvento, EventoDTO entity, Long idUsuario);
+
     public Page<Evento> getEventosByClase(String clase, int page, int size);
 
 }


### PR DESCRIPTION
## Summary
- ensure only the logged in user can update their own account
- add update endpoint for eventos requiring organizer ownership
- expose `/eventos/**` through security config

## Testing
- `./mvnw -q test` *(fails: cannot fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68531f4dcf388324b15fd24552e44019