### PR TITLE
Add geolocation fields to events

### DIFF
--- a/src/main/java/com/cultureclub/cclub/entity/Evento.java
+++ b/src/main/java/com/cultureclub/cclub/entity/Evento.java
@@ -52,6 +52,12 @@ public class Evento {
     private Date fin;
 
     @Column
+    private Double latitud;
+
+    @Column
+    private Double longitud;
+
+    @Column
     private Integer calificacion = 0;
 
     @Column

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
@@ -13,5 +13,7 @@ public class EventoDTO {
     int precio;
     Date inicio;
     Date fin;
+    Double latitud;
+    Double longitud;
     String clase;
 }

--- a/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
@@ -14,6 +14,8 @@ public class EventoMapper {
         dto.setPrecio(evento.getPrecio());
         dto.setInicio(evento.getInicio());
         dto.setFin(evento.getFin());
+        dto.setLatitud(evento.getLatitud());
+        dto.setLongitud(evento.getLongitud());
         dto.setClase(evento.getClase().name());
         return dto;
     }
@@ -27,6 +29,8 @@ public class EventoMapper {
         evento.setPrecio(dto.getPrecio());
         evento.setInicio(dto.getInicio());
         evento.setFin(dto.getFin());
+        evento.setLatitud(dto.getLatitud());
+        evento.setLongitud(dto.getLongitud());
         if (dto.getClase() != null) {
             evento.setClase(com.cultureclub.cclub.entity.enumeradores.ClaseEvento.valueOf(dto.getClase()));
         }

--- a/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
@@ -56,6 +56,8 @@ public class EventoServiceImpl implements EventoService {
             evento.setPrecio(entity.getPrecio());
             evento.setInicio(entity.getInicio());
             evento.setFin(entity.getFin());
+            evento.setLatitud(entity.getLatitud());
+            evento.setLongitud(entity.getLongitud());
             evento.setClase(ClaseEvento.valueOf(entity.getClase()));
             // Buscar y asignar el organizador
             Usuario organizador = usuarioService.getUsuarioById(idUsuario)
@@ -106,6 +108,12 @@ public class EventoServiceImpl implements EventoService {
         }
         if (entity.getFin() != null) {
             evento.setFin(entity.getFin());
+        }
+        if (entity.getLatitud() != null) {
+            evento.setLatitud(entity.getLatitud());
+        }
+        if (entity.getLongitud() != null) {
+            evento.setLongitud(entity.getLongitud());
         }
         if (entity.getClase() != null) {
             evento.setClase(ClaseEvento.valueOf(entity.getClase()));


### PR DESCRIPTION
## Summary
- allow storing latitude and longitude in `Evento`
- expose new fields in `EventoDTO`
- map new fields in `EventoMapper`
- persist and update coordinates in `EventoServiceImpl`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68532eec6e1083248fe53c71028b577d