### PR TITLE
Add geolocation fields to events

### DIFF
--- a/src/main/java/com/cultureclub/cclub/controller/EventoController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/EventoController.java
@@ -76,4 +76,18 @@ public class EventoController {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    @GetMapping("/ciudad/{ciudad}")
+    public ResponseEntity<Page<EventoDTO>> getEventosByCiudad(
+            @PathVariable String ciudad,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (page >= 0 && size >= 0) {
+            Page<Evento> eventoPage = eventoService.getEventosByCiudad(ciudad, page, size);
+            Page<EventoDTO> dtoPage = eventoPage.map(EventoMapper::toDTO);
+            return ResponseEntity.ok(dtoPage);
+        } else {
+            return ResponseEntity.badRequest().build();
+        }
+    }
 }

--- a/src/main/java/com/cultureclub/cclub/entity/Evento.java
+++ b/src/main/java/com/cultureclub/cclub/entity/Evento.java
@@ -52,6 +52,12 @@ public class Evento {
     private Date fin;
 
     @Column
+    private Double latitud;
+
+    @Column
+    private Double longitud;
+
+    @Column
     private Integer calificacion = 0;
 
     @Column

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
@@ -13,5 +13,7 @@ public class EventoDTO {
     int precio;
     Date inicio;
     Date fin;
+    Double latitud;
+    Double longitud;
     String clase;
 }

--- a/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
@@ -14,6 +14,8 @@ public class EventoMapper {
         dto.setPrecio(evento.getPrecio());
         dto.setInicio(evento.getInicio());
         dto.setFin(evento.getFin());
+        dto.setLatitud(evento.getLatitud());
+        dto.setLongitud(evento.getLongitud());
         dto.setClase(evento.getClase().name());
         return dto;
     }
@@ -27,6 +29,8 @@ public class EventoMapper {
         evento.setPrecio(dto.getPrecio());
         evento.setInicio(dto.getInicio());
         evento.setFin(dto.getFin());
+        evento.setLatitud(dto.getLatitud());
+        evento.setLongitud(dto.getLongitud());
         if (dto.getClase() != null) {
             evento.setClase(com.cultureclub.cclub.entity.enumeradores.ClaseEvento.valueOf(dto.getClase()));
         }

--- a/src/main/java/com/cultureclub/cclub/repository/EventoRepository.java
+++ b/src/main/java/com/cultureclub/cclub/repository/EventoRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import com.cultureclub.cclub.entity.Evento;
 import com.cultureclub.cclub.entity.enumeradores.ClaseEvento;
+import com.cultureclub.cclub.entity.Ciudad;
 
 @Repository
 public interface EventoRepository extends JpaRepository<Evento, Long> {
@@ -18,4 +19,6 @@ public interface EventoRepository extends JpaRepository<Evento, Long> {
     List<Evento> findByNombre(String nombre);
 
     Page<Evento> findByClase(ClaseEvento claseEvento, Pageable pageable);
+
+    Page<Evento> findByUsuarioOrganizador_Ciudad(Ciudad ciudad, Pageable pageable);
 }

--- a/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
@@ -14,6 +14,7 @@ import com.cultureclub.cclub.entity.Evento;
 import com.cultureclub.cclub.entity.Usuario;
 import com.cultureclub.cclub.entity.dto.EventoDTO;
 import com.cultureclub.cclub.entity.enumeradores.ClaseEvento;
+import com.cultureclub.cclub.entity.Ciudad;
 import com.cultureclub.cclub.repository.EventoRepository;
 import com.cultureclub.cclub.repository.UsuarioRepository;
 import com.cultureclub.cclub.service.Int.EventoService;
@@ -56,6 +57,8 @@ public class EventoServiceImpl implements EventoService {
             evento.setPrecio(entity.getPrecio());
             evento.setInicio(entity.getInicio());
             evento.setFin(entity.getFin());
+            evento.setLatitud(entity.getLatitud());
+            evento.setLongitud(entity.getLongitud());
             evento.setClase(ClaseEvento.valueOf(entity.getClase()));
             // Buscar y asignar el organizador
             Usuario organizador = usuarioService.getUsuarioById(idUsuario)
@@ -107,6 +110,12 @@ public class EventoServiceImpl implements EventoService {
         if (entity.getFin() != null) {
             evento.setFin(entity.getFin());
         }
+        if (entity.getLatitud() != null) {
+            evento.setLatitud(entity.getLatitud());
+        }
+        if (entity.getLongitud() != null) {
+            evento.setLongitud(entity.getLongitud());
+        }
         if (entity.getClase() != null) {
             evento.setClase(ClaseEvento.valueOf(entity.getClase()));
         }
@@ -126,6 +135,20 @@ public class EventoServiceImpl implements EventoService {
             throw new IllegalArgumentException("Clase de evento no válida: " + clase);
         }
         return eventoRepository.findByClase(claseEvento, PageRequest.of(page, size));
+    }
+
+    @Override
+    public Page<Evento> getEventosByCiudad(String ciudad, int page, int size) {
+        if (page < 0 || size < 0) {
+            throw new IllegalArgumentException("Los parámetros de paginación no pueden ser negativos");
+        }
+        Ciudad ciudadEnum;
+        try {
+            ciudadEnum = Ciudad.valueOf(ciudad.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Ciudad no válida: " + ciudad);
+        }
+        return eventoRepository.findByUsuarioOrganizador_Ciudad(ciudadEnum, PageRequest.of(page, size));
     }
 
 }

--- a/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
@@ -17,4 +17,6 @@ public interface EventoService {
 
     public Page<Evento> getEventosByClase(String clase, int page, int size);
 
+    public Page<Evento> getEventosByCiudad(String ciudad, int page, int size);
+
 }


### PR DESCRIPTION
## Summary
- allow storing latitude and longitude in `Evento`
- expose new fields in `EventoDTO`
- map new fields in `EventoMapper`
- persist and update coordinates in `EventoServiceImpl`
- add API endpoint to list events by city

## Testing
- `bash ./mvnw -q test` *(fails: Failed to fetch from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68532eec6e1083248fe53c71028b577d