### PR TITLE
Implement event following and reviews

### DIFF
--- a/src/main/java/com/cultureclub/cclub/controller/EventoController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/EventoController.java
@@ -12,6 +12,7 @@ import com.cultureclub.cclub.entity.Evento;
 import com.cultureclub.cclub.entity.dto.EventoDTO;
 import com.cultureclub.cclub.mapper.EventoMapper;
 import com.cultureclub.cclub.service.Int.EventoService;
+import com.cultureclub.cclub.service.Int.NotificacionService;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +29,9 @@ public class EventoController {
     @Autowired
     private EventoService eventoService;
 
+    @Autowired
+    private NotificacionService notificacionService;
+
     @PostMapping("/{idUsuario}")
     public ResponseEntity<EventoDTO> publicarEvento(@RequestBody EventoDTO entity, @PathVariable Long idUsuario)
             throws Exception {
@@ -42,6 +46,14 @@ public class EventoController {
             @PathVariable Long idEvento) {
         Evento evento = eventoService.updateEvento(idEvento, entity, idUsuario);
         return ResponseEntity.ok(EventoMapper.toDTO(evento));
+    }
+
+    @PostMapping("/{idEvento}/notificar")
+    public ResponseEntity<String> notificarSeguidores(
+            @PathVariable Long idEvento,
+            @RequestBody String mensaje) {
+        notificacionService.enviarNotificacion(idEvento, mensaje);
+        return ResponseEntity.ok("Notificacion enviada");
     }
 
     @GetMapping("")

--- a/src/main/java/com/cultureclub/cclub/controller/ResenaController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/ResenaController.java
@@ -1,0 +1,47 @@
+package com.cultureclub.cclub.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cultureclub.cclub.entity.Resena;
+import com.cultureclub.cclub.entity.dto.ResenaDTO;
+import com.cultureclub.cclub.mapper.ResenaMapper;
+import com.cultureclub.cclub.service.Int.ResenaService;
+
+@RestController
+@RequestMapping("/resenas")
+public class ResenaController {
+    @Autowired
+    private ResenaService resenaService;
+
+    @PostMapping("/{idUsuario}/{idEvento}")
+    public ResponseEntity<ResenaDTO> crearResena(
+            @PathVariable Long idUsuario,
+            @PathVariable Long idEvento,
+            @RequestBody ResenaDTO resenaDTO) {
+        Resena resena = resenaService.agregarResena(idUsuario, idEvento, resenaDTO);
+        return ResponseEntity.ok(ResenaMapper.toDTO(resena));
+    }
+
+    @GetMapping("/evento/{idEvento}")
+    public ResponseEntity<List<ResenaDTO>> getResenasEvento(@PathVariable Long idEvento) {
+        List<ResenaDTO> dtos = resenaService.obtenerResenasEvento(idEvento)
+                .stream().map(ResenaMapper::toDTO).toList();
+        return ResponseEntity.ok(dtos);
+    }
+
+    @GetMapping("/usuario/{idUsuario}")
+    public ResponseEntity<List<ResenaDTO>> getResenasUsuario(@PathVariable Long idUsuario) {
+        List<ResenaDTO> dtos = resenaService.obtenerResenasUsuario(idUsuario)
+                .stream().map(ResenaMapper::toDTO).toList();
+        return ResponseEntity.ok(dtos);
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/controller/UsuarioController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/UsuarioController.java
@@ -17,6 +17,7 @@ import com.cultureclub.cclub.mapper.EntradaMapper;
 import com.cultureclub.cclub.mapper.ReporteMapper;
 import com.cultureclub.cclub.mapper.UsuarioMapper;
 import com.cultureclub.cclub.service.Int.UsuarioService;
+import com.cultureclub.cclub.service.Int.NotificacionService;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +32,9 @@ public class UsuarioController {
 
     @Autowired
     private UsuarioService usuarioService;
+
+    @Autowired
+    private NotificacionService notificacionService;
 
     @GetMapping("/{id}")
     public ResponseEntity<Object> getUsuarioById(@PathVariable Long id) {
@@ -81,6 +85,22 @@ public class UsuarioController {
     public String seguirUsuario(@PathVariable Long usuarioId, @PathVariable Long usuarioSeguidoId) {
         usuarioService.seguirUsuario(usuarioId, usuarioSeguidoId);
         return "Usuario seguido correctamente";
+    }
+
+    @PutMapping("/{usuarioId}/seguir-evento/{eventoId}")
+    public String seguirEvento(@PathVariable Long usuarioId, @PathVariable Long eventoId) {
+        usuarioService.seguirEvento(usuarioId, eventoId);
+        return "Evento seguido correctamente";
+    }
+
+    @GetMapping("/{usuarioId}/eventos-asistidos")
+    public ResponseEntity<Object> getEventosAsistidos(@PathVariable Long usuarioId) {
+        return ResponseEntity.ok(usuarioService.getEventosAsistidos(usuarioId));
+    }
+
+    @GetMapping("/{usuarioId}/notificaciones")
+    public ResponseEntity<Object> getNotificaciones(@PathVariable Long usuarioId) {
+        return ResponseEntity.ok(notificacionService.obtenerNotificacionesUsuario(usuarioId));
     }
 
 }

--- a/src/main/java/com/cultureclub/cclub/entity/EventoAsistido.java
+++ b/src/main/java/com/cultureclub/cclub/entity/EventoAsistido.java
@@ -1,0 +1,17 @@
+package com.cultureclub.cclub.entity;
+
+import java.sql.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Data;
+
+@Embeddable
+@Data
+public class EventoAsistido {
+    @Column(name = "nombre_evento")
+    private String nombreEvento;
+
+    @Column(name = "fecha_evento")
+    private Date fechaEvento;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/Notificacion.java
+++ b/src/main/java/com/cultureclub/cclub/entity/Notificacion.java
@@ -1,0 +1,36 @@
+package com.cultureclub.cclub.entity;
+
+import java.sql.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Table(name = "notificacion")
+@Data
+public class Notificacion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idNotificacion;
+
+    @ManyToOne
+    @JoinColumn(name = "evento_id", nullable = false)
+    private Evento evento;
+
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column
+    private String mensaje;
+
+    @Column
+    private Date fecha;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/Resena.java
+++ b/src/main/java/com/cultureclub/cclub/entity/Resena.java
@@ -1,0 +1,36 @@
+package com.cultureclub.cclub.entity;
+
+import java.sql.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Table(name = "resena")
+@Data
+public class Resena {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idResena;
+
+    @ManyToOne
+    @JoinColumn(name = "evento_id", nullable = false)
+    private Evento evento;
+
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column
+    private String contenido;
+
+    @Column
+    private Date fecha;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/Usuario.java
+++ b/src/main/java/com/cultureclub/cclub/entity/Usuario.java
@@ -2,6 +2,8 @@ package com.cultureclub.cclub.entity;
 
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import com.cultureclub.cclub.entity.EventoAsistido;
 
 import com.cultureclub.cclub.entity.enumeradores.Ciudad;
 import com.cultureclub.cclub.entity.enumeradores.Rol;
@@ -12,6 +14,7 @@ import com.cultureclub.cclub.entity.reportes.ReporteUsuario;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Lob;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -60,12 +63,22 @@ public class Usuario {
     @Column
     private int telefono;
 
+    @Lob
+    @Column(name = "foto")
+    private byte[] foto;
+
     @ManyToMany // Many usuarios can follow many other usuarios
     @JoinTable(name = "usuario_seguidos", joinColumns = @JoinColumn(name = "seguidor_id"), inverseJoinColumns = @JoinColumn(name = "seguido_id"))
     private List<Usuario> seguidos;
 
     @ManyToMany(mappedBy = "seguidos") // Reverse relationship for followers
     private List<Usuario> seguidores;
+
+    @ManyToMany(mappedBy = "seguidores")
+    private List<Evento> eventosSeguidos = new ArrayList<>();
+
+    @ElementCollection
+    private List<EventoAsistido> eventosAsistidos = new ArrayList<>();
 
     @OneToMany(mappedBy = "compradorUsuario", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Entrada> entradas;

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EventoAsistidoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EventoAsistidoDTO.java
@@ -1,0 +1,11 @@
+package com.cultureclub.cclub.entity.dto;
+
+import java.sql.Date;
+
+import lombok.Data;
+
+@Data
+public class EventoAsistidoDTO {
+    private String nombreEvento;
+    private Date fechaEvento;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/dto/NotificacionDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/NotificacionDTO.java
@@ -1,0 +1,14 @@
+package com.cultureclub.cclub.entity.dto;
+
+import java.sql.Date;
+
+import lombok.Data;
+
+@Data
+public class NotificacionDTO {
+    private Long idNotificacion;
+    private Long idEvento;
+    private Long idUsuario;
+    private String mensaje;
+    private Date fecha;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/dto/ResenaDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/ResenaDTO.java
@@ -1,0 +1,14 @@
+package com.cultureclub.cclub.entity.dto;
+
+import java.sql.Date;
+
+import lombok.Data;
+
+@Data
+public class ResenaDTO {
+    private Long idResena;
+    private Long idEvento;
+    private Long idUsuario;
+    private String contenido;
+    private Date fecha;
+}

--- a/src/main/java/com/cultureclub/cclub/entity/dto/UsuarioDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/UsuarioDTO.java
@@ -17,4 +17,5 @@ public class UsuarioDTO {
     private String password;
     private Integer telefono = 0;
     private Integer puntuacion = 0;
+    private byte[] foto;
 }

--- a/src/main/java/com/cultureclub/cclub/mapper/EventoAsistidoMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/EventoAsistidoMapper.java
@@ -1,0 +1,20 @@
+package com.cultureclub.cclub.mapper;
+
+import com.cultureclub.cclub.entity.EventoAsistido;
+import com.cultureclub.cclub.entity.dto.EventoAsistidoDTO;
+
+public class EventoAsistidoMapper {
+    public static EventoAsistidoDTO toDTO(EventoAsistido e) {
+        EventoAsistidoDTO dto = new EventoAsistidoDTO();
+        dto.setNombreEvento(e.getNombreEvento());
+        dto.setFechaEvento(e.getFechaEvento());
+        return dto;
+    }
+
+    public static EventoAsistido toEntity(EventoAsistidoDTO dto) {
+        EventoAsistido e = new EventoAsistido();
+        e.setNombreEvento(dto.getNombreEvento());
+        e.setFechaEvento(dto.getFechaEvento());
+        return e;
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/mapper/NotificacionMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/NotificacionMapper.java
@@ -1,0 +1,28 @@
+package com.cultureclub.cclub.mapper;
+
+import com.cultureclub.cclub.entity.Evento;
+import com.cultureclub.cclub.entity.Notificacion;
+import com.cultureclub.cclub.entity.Usuario;
+import com.cultureclub.cclub.entity.dto.NotificacionDTO;
+
+public class NotificacionMapper {
+    public static NotificacionDTO toDTO(Notificacion notif) {
+        NotificacionDTO dto = new NotificacionDTO();
+        dto.setIdNotificacion(notif.getIdNotificacion());
+        dto.setIdEvento(notif.getEvento().getIdEvento());
+        dto.setIdUsuario(notif.getUsuario().getIdUsuario());
+        dto.setMensaje(notif.getMensaje());
+        dto.setFecha(notif.getFecha());
+        return dto;
+    }
+
+    public static Notificacion toEntity(NotificacionDTO dto, Evento evento, Usuario usuario) {
+        Notificacion n = new Notificacion();
+        n.setIdNotificacion(dto.getIdNotificacion());
+        n.setEvento(evento);
+        n.setUsuario(usuario);
+        n.setMensaje(dto.getMensaje());
+        n.setFecha(dto.getFecha());
+        return n;
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/mapper/ResenaMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/ResenaMapper.java
@@ -1,0 +1,28 @@
+package com.cultureclub.cclub.mapper;
+
+import com.cultureclub.cclub.entity.Resena;
+import com.cultureclub.cclub.entity.Evento;
+import com.cultureclub.cclub.entity.Usuario;
+import com.cultureclub.cclub.entity.dto.ResenaDTO;
+
+public class ResenaMapper {
+    public static ResenaDTO toDTO(Resena resena) {
+        ResenaDTO dto = new ResenaDTO();
+        dto.setIdResena(resena.getIdResena());
+        dto.setIdEvento(resena.getEvento().getIdEvento());
+        dto.setIdUsuario(resena.getUsuario().getIdUsuario());
+        dto.setContenido(resena.getContenido());
+        dto.setFecha(resena.getFecha());
+        return dto;
+    }
+
+    public static Resena toEntity(ResenaDTO dto, Evento evento, Usuario usuario) {
+        Resena r = new Resena();
+        r.setIdResena(dto.getIdResena());
+        r.setEvento(evento);
+        r.setUsuario(usuario);
+        r.setContenido(dto.getContenido());
+        r.setFecha(dto.getFecha());
+        return r;
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/mapper/UsuarioMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/UsuarioMapper.java
@@ -16,6 +16,7 @@ public class UsuarioMapper {
         dto.setPuntuacion(usuario.getPuntuacion());
         dto.setTelefono(usuario.getTelefono());
         dto.setRoles(dto.getRoles());
+        dto.setFoto(usuario.getFoto());
         return dto;
     }
 
@@ -34,6 +35,7 @@ public class UsuarioMapper {
         // Set other fields as needed (e.g., password, premium)
         usuario.setPassword(dto.getPassword());
         usuario.setRoles(dto.getRoles() != dto.getRoles() ? dto.getRoles() : usuario.getRoles());
+        usuario.setFoto(dto.getFoto());
         return usuario;
     }
 }

--- a/src/main/java/com/cultureclub/cclub/repository/NotificacionRepository.java
+++ b/src/main/java/com/cultureclub/cclub/repository/NotificacionRepository.java
@@ -1,0 +1,11 @@
+package com.cultureclub.cclub.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cultureclub.cclub.entity.Notificacion;
+
+public interface NotificacionRepository extends JpaRepository<Notificacion, Long> {
+    List<Notificacion> findByUsuario_IdUsuario(Long idUsuario);
+}

--- a/src/main/java/com/cultureclub/cclub/repository/ResenaRepository.java
+++ b/src/main/java/com/cultureclub/cclub/repository/ResenaRepository.java
@@ -1,0 +1,12 @@
+package com.cultureclub.cclub.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cultureclub.cclub.entity.Resena;
+
+public interface ResenaRepository extends JpaRepository<Resena, Long> {
+    List<Resena> findByEvento_IdEvento(Long idEvento);
+    List<Resena> findByUsuario_IdUsuario(Long idUsuario);
+}

--- a/src/main/java/com/cultureclub/cclub/service/Impl/NotificacionServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/NotificacionServiceImpl.java
@@ -1,0 +1,42 @@
+package com.cultureclub.cclub.service.Impl;
+
+import java.sql.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.cultureclub.cclub.entity.Evento;
+import com.cultureclub.cclub.entity.Notificacion;
+import com.cultureclub.cclub.entity.Usuario;
+import com.cultureclub.cclub.repository.EventoRepository;
+import com.cultureclub.cclub.repository.NotificacionRepository;
+import com.cultureclub.cclub.service.Int.NotificacionService;
+
+@Service
+public class NotificacionServiceImpl implements NotificacionService {
+    @Autowired
+    private EventoRepository eventoRepository;
+    @Autowired
+    private NotificacionRepository notificacionRepository;
+
+    @Override
+    public void enviarNotificacion(Long idEvento, String mensaje) {
+        Evento evento = eventoRepository.findById(idEvento)
+                .orElseThrow(() -> new IllegalArgumentException("Evento no encontrado"));
+        Date fecha = new Date(System.currentTimeMillis());
+        for (Usuario seguidor : evento.getSeguidores()) {
+            Notificacion n = new Notificacion();
+            n.setEvento(evento);
+            n.setUsuario(seguidor);
+            n.setMensaje(mensaje);
+            n.setFecha(fecha);
+            notificacionRepository.save(n);
+        }
+    }
+
+    @Override
+    public List<Notificacion> obtenerNotificacionesUsuario(Long idUsuario) {
+        return notificacionRepository.findByUsuario_IdUsuario(idUsuario);
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/service/Impl/ResenaServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/ResenaServiceImpl.java
@@ -1,0 +1,46 @@
+package com.cultureclub.cclub.service.Impl;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.cultureclub.cclub.entity.Evento;
+import com.cultureclub.cclub.entity.Resena;
+import com.cultureclub.cclub.entity.Usuario;
+import com.cultureclub.cclub.entity.dto.ResenaDTO;
+import com.cultureclub.cclub.mapper.ResenaMapper;
+import com.cultureclub.cclub.repository.EventoRepository;
+import com.cultureclub.cclub.repository.ResenaRepository;
+import com.cultureclub.cclub.repository.UsuarioRepository;
+import com.cultureclub.cclub.service.Int.ResenaService;
+
+@Service
+public class ResenaServiceImpl implements ResenaService {
+    @Autowired
+    private ResenaRepository resenaRepository;
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+    @Autowired
+    private EventoRepository eventoRepository;
+
+    @Override
+    public Resena agregarResena(Long idUsuario, Long idEvento, ResenaDTO resenaDTO) {
+        Usuario usuario = usuarioRepository.findById(idUsuario)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado"));
+        Evento evento = eventoRepository.findById(idEvento)
+                .orElseThrow(() -> new IllegalArgumentException("Evento no encontrado"));
+        Resena resena = ResenaMapper.toEntity(resenaDTO, evento, usuario);
+        return resenaRepository.save(resena);
+    }
+
+    @Override
+    public List<Resena> obtenerResenasEvento(Long idEvento) {
+        return resenaRepository.findByEvento_IdEvento(idEvento);
+    }
+
+    @Override
+    public List<Resena> obtenerResenasUsuario(Long idUsuario) {
+        return resenaRepository.findByUsuario_IdUsuario(idUsuario);
+    }
+}

--- a/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.cultureclub.cclub.entity.Entrada;
 import com.cultureclub.cclub.entity.Evento;
+import com.cultureclub.cclub.entity.EventoAsistido;
 import com.cultureclub.cclub.entity.Usuario;
 import com.cultureclub.cclub.entity.dto.EntradaDTO;
 import com.cultureclub.cclub.entity.dto.UsuarioDTO;
@@ -164,6 +165,12 @@ public class UsuarioServiceImpl implements UsuarioService {
         usuario.getEntradas().add(entrada);
         evento.getEntradas().add(entrada);
 
+        EventoAsistido asistido = new EventoAsistido();
+        asistido.setNombreEvento(evento.getNombre());
+        asistido.setFechaEvento(entradaDTO.getFechaUso());
+        usuario.getEventosAsistidos().add(asistido);
+        usuarioRepository.save(usuario);
+
         return Optional.ofNullable(entradaRepository.save(entrada));
 
     }
@@ -190,5 +197,27 @@ public class UsuarioServiceImpl implements UsuarioService {
         } else {
             System.out.println("El usuario " + usuario.getNombre() + " ya sigue a " + usuarioSeguido.getNombre());
         }
+    }
+
+    @Override
+    public void seguirEvento(Long usuarioId, Long eventoId) {
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado con ID: " + usuarioId));
+        Evento evento = eventoRepository.findById(eventoId)
+                .orElseThrow(() -> new IllegalArgumentException("Evento no encontrado con ID: " + eventoId));
+
+        if (!evento.getSeguidores().contains(usuario)) {
+            evento.getSeguidores().add(usuario);
+            usuario.getEventosSeguidos().add(evento);
+            eventoRepository.save(evento);
+            usuarioRepository.save(usuario);
+        }
+    }
+
+    @Override
+    public java.util.List<EventoAsistido> getEventosAsistidos(Long usuarioId) {
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado con ID: " + usuarioId));
+        return usuario.getEventosAsistidos();
     }
 }

--- a/src/main/java/com/cultureclub/cclub/service/Int/NotificacionService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/NotificacionService.java
@@ -1,0 +1,10 @@
+package com.cultureclub.cclub.service.Int;
+
+import java.util.List;
+
+import com.cultureclub.cclub.entity.Notificacion;
+
+public interface NotificacionService {
+    void enviarNotificacion(Long idEvento, String mensaje);
+    List<Notificacion> obtenerNotificacionesUsuario(Long idUsuario);
+}

--- a/src/main/java/com/cultureclub/cclub/service/Int/ResenaService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/ResenaService.java
@@ -1,0 +1,12 @@
+package com.cultureclub.cclub.service.Int;
+
+import java.util.List;
+
+import com.cultureclub.cclub.entity.Resena;
+import com.cultureclub.cclub.entity.dto.ResenaDTO;
+
+public interface ResenaService {
+    Resena agregarResena(Long idUsuario, Long idEvento, ResenaDTO resena);
+    List<Resena> obtenerResenasEvento(Long idEvento);
+    List<Resena> obtenerResenasUsuario(Long idUsuario);
+}

--- a/src/main/java/com/cultureclub/cclub/service/Int/UsuarioService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/UsuarioService.java
@@ -24,4 +24,8 @@ public interface UsuarioService {
 
     void seguirUsuario(Long usuarioId, Long usuarioSeguidoId);
 
+    void seguirEvento(Long usuarioId, Long eventoId);
+
+    java.util.List<com.cultureclub.cclub.entity.EventoAsistido> getEventosAsistidos(Long usuarioId);
+
 }


### PR DESCRIPTION
## Summary
- add storage for attended events and profile photo in `Usuario`
- implement following events
- support user notifications from events
- create review and notification services
- expose controllers for reviews and new user/event endpoints

## Testing
- `./mvnw -q test` *(fails: network access needed for Maven)*

------
https://chatgpt.com/codex/tasks/task_e_685b4e8096248324a6a7597dd4571a54