### PR TITLE
Add event descriptions and price filter

### DIFF
--- a/src/main/java/com/cultureclub/cclub/controller/EventoController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/EventoController.java
@@ -102,4 +102,18 @@ public class EventoController {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    @GetMapping("/precio/{precio}")
+    public ResponseEntity<Page<EventoDTO>> getEventosByPrecio(
+            @PathVariable int precio,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (page >= 0 && size >= 0) {
+            Page<Evento> eventoPage = eventoService.getEventosByPrecio(precio, page, size);
+            Page<EventoDTO> dtoPage = eventoPage.map(EventoMapper::toDTO);
+            return ResponseEntity.ok(dtoPage);
+        } else {
+            return ResponseEntity.badRequest().build();
+        }
+    }
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/AuthRequestDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/AuthRequestDTO.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class AuthRequestDTO {
-    private String email;
-    private String password;
+    private String email = "";
+    private String password = "";
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/AuthResponseDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/AuthResponseDTO.java
@@ -2,10 +2,12 @@ package com.cultureclub.cclub.entity.dto.Authentication;
 
 
 public class AuthResponseDTO {
-    private String token;
+    private String token = "";
+
     public AuthResponseDTO(String token) {
         this.token = token;
     }
+
     public String getToken() {
         return token;
     }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/ErrorResponseDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/Authentication/ErrorResponseDTO.java
@@ -1,9 +1,11 @@
 package com.cultureclub.cclub.entity.dto.Authentication;
 
 public class ErrorResponseDTO {
-    private String error;
+    private String error = "";
+
     public ErrorResponseDTO(String error) {
         this.error = error;
     }
+
     public String getError() { return error; }
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/CalificacionDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/CalificacionDTO.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class CalificacionDTO {
-    private Integer calificacion;
+    private Integer calificacion = 0;
     // getters and setters
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EntradaDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EntradaDTO.java
@@ -5,11 +5,11 @@ import lombok.Data;
 
 @Data
 public class EntradaDTO {
-    private Long idEntrada;
-    private String tipoEntrada;
-    private Long idEvento;
-    private Long idCompradorUsuario;
-    private Date fechaCompra;
-    private Date fechaUso;
-    private int precioPagado;
+    private Long idEntrada = 0L;
+    private String tipoEntrada = "";
+    private Long idEvento = 0L;
+    private Long idCompradorUsuario = 0L;
+    private Date fechaCompra = new Date(System.currentTimeMillis());
+    private Date fechaUso = new Date(System.currentTimeMillis());
+    private int precioPagado = 0;
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EventoAsistidoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EventoAsistidoDTO.java
@@ -6,6 +6,6 @@ import lombok.Data;
 
 @Data
 public class EventoAsistidoDTO {
-    private String nombreEvento;
-    private Date fechaEvento;
+    private String nombreEvento = "";
+    private Date fechaEvento = new Date(System.currentTimeMillis());
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/EventoDTO.java
@@ -6,15 +6,16 @@ import lombok.Data;
 
 @Data
 public class EventoDTO {
-    long idEvento;
-    long idOrganizador;
-    String nombre;
-    boolean entrada;
-    int precio;
-    Date inicio;
-    Date fin;
-    Double latitud;
-    Double longitud;
-    String clase;
-    byte[] imagen;
+    private long idEvento = 0L;
+    private long idOrganizador = 0L;
+    private String nombre = "";
+    private String descripcion = "";
+    private boolean entrada = false;
+    private int precio = 0;
+    private Date inicio = new Date(System.currentTimeMillis());
+    private Date fin = new Date(System.currentTimeMillis());
+    private Double latitud = 0.0;
+    private Double longitud = 0.0;
+    private String clase = "";
+    private byte[] imagen = new byte[0];
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/NotificacionDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/NotificacionDTO.java
@@ -6,9 +6,9 @@ import lombok.Data;
 
 @Data
 public class NotificacionDTO {
-    private Long idNotificacion;
-    private Long idEvento;
-    private Long idUsuario;
-    private String mensaje;
-    private Date fecha;
+    private Long idNotificacion = 0L;
+    private Long idEvento = 0L;
+    private Long idUsuario = 0L;
+    private String mensaje = "";
+    private Date fecha = new Date(System.currentTimeMillis());
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/ResenaDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/ResenaDTO.java
@@ -6,9 +6,9 @@ import lombok.Data;
 
 @Data
 public class ResenaDTO {
-    private Long idResena;
-    private Long idEvento;
-    private Long idUsuario;
-    private String contenido;
-    private Date fecha;
+    private Long idResena = 0L;
+    private Long idEvento = 0L;
+    private Long idUsuario = 0L;
+    private String contenido = "";
+    private Date fecha = new Date(System.currentTimeMillis());
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/UsuarioDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/UsuarioDTO.java
@@ -8,14 +8,14 @@ import lombok.Data;
 
 @Data
 public class UsuarioDTO {
-    private Long idUsuario;
-    private Set<Rol> roles;
-    private String nombre;
-    private String apellidos;
-    private String ciudad;
-    private String email;
-    private String password;
+    private Long idUsuario = 0L;
+    private Set<Rol> roles = Set.of();
+    private String nombre = "";
+    private String apellidos = "";
+    private String ciudad = "";
+    private String email = "";
+    private String password = "";
     private Integer telefono = 0;
     private Integer puntuacion = 0;
-    private byte[] foto;
+    private byte[] foto = new byte[0];
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteDTO.java
@@ -13,9 +13,9 @@ import lombok.Data;
         @JsonSubTypes.Type(value = ReporteErrorDTO.class, name = "error")
 })
 public class ReporteDTO {
-    private Long idReporte;
-    private Long idEmisor;
-    private Date fecha;
-    private String motivo;
-    private String descripcion;
+    private Long idReporte = 0L;
+    private Long idEmisor = 0L;
+    private Date fecha = new Date(System.currentTimeMillis());
+    private String motivo = "";
+    private String descripcion = "";
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteErrorDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteErrorDTO.java
@@ -6,6 +6,6 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ReporteErrorDTO extends ReporteDTO {
-    private String urlAfectada;
-    private String severidad;
+    private String urlAfectada = "";
+    private String severidad = "";
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteEventoDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteEventoDTO.java
@@ -6,5 +6,5 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ReporteEventoDTO extends ReporteDTO {
-    private Long idEventoReportado;
+    private Long idEventoReportado = 0L;
 }

--- a/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteUsuarioDTO.java
+++ b/src/main/java/com/cultureclub/cclub/entity/dto/reporte/ReporteUsuarioDTO.java
@@ -6,5 +6,5 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ReporteUsuarioDTO extends ReporteDTO {
-    private Long idUsuarioReportado;
+    private Long idUsuarioReportado = 0L;
 }

--- a/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/EventoMapper.java
@@ -10,6 +10,7 @@ public class EventoMapper {
         dto.setIdEvento(evento.getIdEvento());
         dto.setIdOrganizador(evento.getUsuarioOrganizador().getIdUsuario());
         dto.setNombre(evento.getNombre());
+        dto.setDescripcion(evento.getDescripcion());
         dto.setEntrada(evento.isEntrada());
         dto.setPrecio(evento.getPrecio());
         dto.setInicio(evento.getInicio());
@@ -26,6 +27,7 @@ public class EventoMapper {
         evento.setIdEvento(dto.getIdEvento());
         evento.setUsuarioOrganizador(organizador);
         evento.setNombre(dto.getNombre());
+        evento.setDescripcion(dto.getDescripcion());
         evento.setEntrada(dto.isEntrada());
         evento.setPrecio(dto.getPrecio());
         evento.setInicio(dto.getInicio());

--- a/src/main/java/com/cultureclub/cclub/repository/EventoRepository.java
+++ b/src/main/java/com/cultureclub/cclub/repository/EventoRepository.java
@@ -21,4 +21,6 @@ public interface EventoRepository extends JpaRepository<Evento, Long> {
     Page<Evento> findByClase(ClaseEvento claseEvento, Pageable pageable);
 
     Page<Evento> findByUsuarioOrganizador_Ciudad(Ciudad ciudad, Pageable pageable);
+
+    Page<Evento> findByPrecioLessThanEqual(int precio, Pageable pageable);
 }

--- a/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/EventoServiceImpl.java
@@ -53,6 +53,7 @@ public class EventoServiceImpl implements EventoService {
         } else {
             Evento evento = new Evento();
             evento.setNombre(entity.getNombre());
+            evento.setDescripcion(entity.getDescripcion());
             evento.setEntrada(entity.isEntrada());
             evento.setPrecio(entity.getPrecio());
             evento.setInicio(entity.getInicio());
@@ -102,6 +103,9 @@ public class EventoServiceImpl implements EventoService {
 
         if (entity.getNombre() != null) {
             evento.setNombre(entity.getNombre());
+        }
+        if (entity.getDescripcion() != null) {
+            evento.setDescripcion(entity.getDescripcion());
         }
         evento.setEntrada(entity.isEntrada());
         evento.setPrecio(entity.getPrecio());
@@ -153,6 +157,14 @@ public class EventoServiceImpl implements EventoService {
             throw new IllegalArgumentException("Ciudad no válida: " + ciudad);
         }
         return eventoRepository.findByUsuarioOrganizador_Ciudad(ciudadEnum, PageRequest.of(page, size));
+    }
+
+    @Override
+    public Page<Evento> getEventosByPrecio(int precio, int page, int size) {
+        if (page < 0 || size < 0) {
+            throw new IllegalArgumentException("Los parámetros de paginación no pueden ser negativos");
+        }
+        return eventoRepository.findByPrecioLessThanEqual(precio, PageRequest.of(page, size));
     }
 
 }

--- a/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
+++ b/src/main/java/com/cultureclub/cclub/service/Int/EventoService.java
@@ -19,4 +19,6 @@ public interface EventoService {
 
     public Page<Evento> getEventosByCiudad(String ciudad, int page, int size);
 
+    public Page<Evento> getEventosByPrecio(int precio, int page, int size);
+
 }


### PR DESCRIPTION
## Summary
- add description field to `EventoDTO` and default values across all DTOs
- map description in `EventoMapper` and handle it in `EventoServiceImpl`
- allow querying events by price
- expose new `/precio/{precio}` endpoint

## Testing
- `./mvnw -q test` *(fails: unable to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c1b34c2808324841f7d2cf974108a