### PR TITLE
Add additional API tests

### DIFF
--- a/extraDoc/CultureClub API Tests.postman_collection.json
+++ b/extraDoc/CultureClub API Tests.postman_collection.json
@@ -1948,6 +1948,160 @@
 					"response": []
 				}
 			]
-		}
-	]
+		},
+                {
+                        "name": "AdditionalRequests",
+                        "item": [
+                                {
+                                        "name": "seguirEvento",
+                                        "event": [
+                                                {
+                                                        "listen": "test",
+                                                        "script": {
+                                                                "exec": [
+                                                                        "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                                                                ],
+                                                                "type": "text/javascript",
+                                                                "packages": {}
+                                                        }
+                                                }
+                                        ],
+                                        "request": {
+                                                "method": "PUT",
+                                                "header": [
+                                                        {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/usuarios/1/seguir-evento/1",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "usuarios",
+                                                                "1",
+                                                                "seguir-evento",
+                                                                "1"
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "getEventosAsistidos",
+                                        "event": [
+                                                {
+                                                        "listen": "test",
+                                                        "script": {
+                                                                "exec": [
+                                                                        "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                                                                ],
+                                                                "type": "text/javascript",
+                                                                "packages": {}
+                                                        }
+                                                }
+                                        ],
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/usuarios/1/eventos-asistidos",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "usuarios",
+                                                                "1",
+                                                                "eventos-asistidos"
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "getNotificaciones",
+                                        "event": [
+                                                {
+                                                        "listen": "test",
+                                                        "script": {
+                                                                "exec": [
+                                                                        "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                                                                ],
+                                                                "type": "text/javascript",
+                                                                "packages": {}
+                                                        }
+                                                }
+                                        ],
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                        }
+                                                ],
+                                                "url": {
+                                                        "raw": "{{base_url}}/usuarios/1/notificaciones",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "usuarios",
+                                                                "1",
+                                                                "notificaciones"
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "crearResena",
+                                        "event": [
+                                                {
+                                                        "listen": "test",
+                                                        "script": {
+                                                                "exec": [
+                                                                        "pm.test('Status 200', () => pm.response.to.have.status(200));"
+                                                                ],
+                                                                "type": "text/javascript",
+                                                                "packages": {}
+                                                        }
+                                                }
+                                        ],
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [
+                                                        {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                        }
+                                                ],
+                                                "body": {
+                                                        "mode": "raw",
+                                                        "raw": "{\"contenido\":\"Buena\"}"
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/resenas/1/1",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "resenas",
+                                                                "1",
+                                                                "1"
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                }
+                        ]
+                },
+        ]
 }


### PR DESCRIPTION
## Summary
- expand API Postman collection with new tests for following events, listing attended events, checking notifications and posting a review

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1f53ad2c8324a945efa74f985829