### PR TITLE
Fix admin role naming

### DIFF
--- a/src/main/java/com/cultureclub/cclub/controller/GestorUsuarioController.java
+++ b/src/main/java/com/cultureclub/cclub/controller/GestorUsuarioController.java
@@ -39,7 +39,7 @@ public class GestorUsuarioController {
     @GetMapping("/admin")
     public ResponseEntity<Object> getAdmingUsuarios(
             @RequestParam(required = false, defaultValue = "true") boolean isAdmin) {
-        return ResponseEntity.ok(gestorUsuarioService.getPremiumUsuarios(isAdmin));
+        return ResponseEntity.ok(gestorUsuarioService.getAdminUsuarios(isAdmin));
     }
 
     @GetMapping("/all")

--- a/src/main/java/com/cultureclub/cclub/security/SecurityConfig.java
+++ b/src/main/java/com/cultureclub/cclub/security/SecurityConfig.java
@@ -36,9 +36,9 @@ public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         .cors(org.springframework.security.config.Customizer.withDefaults()) // 👈 Configura CORS usando Customizer (Spring Security 6+)
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/api/auth/**").permitAll()
-            .requestMatchers("/gestorUsuarios/**").hasRole("ADMIN")
-            .requestMatchers("/premium/**").hasAnyRole("ADMIN", "PREMIUM")
-            .requestMatchers("/usuarios/**").hasAnyRole("ADMIN", "PREMIUM", "USUARIO")
+            .requestMatchers("/gestorUsuarios/**").hasRole("ADMINISTRADOR")
+            .requestMatchers("/premium/**").hasAnyRole("ADMINISTRADOR", "PREMIUM")
+            .requestMatchers("/usuarios/**").hasAnyRole("ADMINISTRADOR", "PREMIUM", "USUARIO")
             .requestMatchers("/eventos/**").permitAll()
             .anyRequest().denyAll()
         )

--- a/src/test/java/com/cultureclub/cclub/security/JwtRoleTest.java
+++ b/src/test/java/com/cultureclub/cclub/security/JwtRoleTest.java
@@ -1,0 +1,28 @@
+package com.cultureclub.cclub.security;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.cultureclub.cclub.entity.Usuario;
+import com.cultureclub.cclub.entity.enumeradores.Rol;
+
+class JwtRoleTest {
+
+    private final JwtUtil jwtUtil = new JwtUtil();
+
+    @Test
+    void tokenContainsRoleAdministrador() {
+        Usuario admin = new Usuario();
+        admin.setEmail("admin@example.com");
+        admin.setPassword("secret");
+        admin.setRoles(Set.of(Rol.ADMINISTRADOR));
+
+        UsuarioDetails userDetails = new UsuarioDetails(admin);
+        String token = jwtUtil.generateToken(userDetails);
+
+        assertTrue(jwtUtil.extractRoles(token).contains("ROLE_ADMINISTRADOR"));
+    }
+}


### PR DESCRIPTION
## Summary
- use `ADMINISTRADOR` role name in security configuration
- wire admin lookup method in GestorUsuario controller
- add test ensuring admin JWT tokens include `ROLE_ADMINISTRADOR`

## Testing
- `sh ./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_685c352bfb8483248c79316a029a17ad