### PR TITLE
Store user id in JWT

### DIFF
--- a/src/test/java/com/cultureclub/cclub/security/JwtRoleTest.java
+++ b/src/test/java/com/cultureclub/cclub/security/JwtRoleTest.java
@@ -1,5 +1,6 @@
 package com.cultureclub.cclub.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -16,6 +17,7 @@ class JwtRoleTest {
     @Test
     void tokenContainsRoleAdministrador() {
         Usuario admin = new Usuario();
+        admin.setIdUsuario(1L);
         admin.setEmail("admin@example.com");
         admin.setPassword("secret");
         admin.setRoles(Set.of(Rol.ADMINISTRADOR));
@@ -24,5 +26,6 @@ class JwtRoleTest {
         String token = jwtUtil.generateToken(userDetails);
 
         assertTrue(jwtUtil.extractRoles(token).contains("ROLE_ADMINISTRADOR"));
+        assertEquals(1L, jwtUtil.extractUserId(token));
     }
 }


### PR DESCRIPTION
## Summary
- include the authenticated user id when creating JWT tokens
- expose `extractUserId` method
- test that JWT contains the id

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies - no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685c36e79e9483248e492948ac577d5b