### PR TITLE
Fix ReporteEvento construction

### DIFF
--- a/src/main/java/com/cultureclub/cclub/mapper/ReporteMapper.java
+++ b/src/main/java/com/cultureclub/cclub/mapper/ReporteMapper.java
@@ -59,9 +59,12 @@ public class ReporteMapper {
             reporte = r;
         } else if (dto instanceof ReporteEventoDTO eventoDto) {
             ReporteEvento r = new ReporteEvento();
-            com.cultureclub.cclub.entity.dto.EventoDTO eventoDtoTemp = new com.cultureclub.cclub.entity.dto.EventoDTO();
-            eventoDtoTemp.setIdEvento(eventoDto.getIdEventoReportado());
-            r.setEventoReportado(EventoMapper.toEntity(eventoDtoTemp, null));
+            // Only the ID of the event is required when creating the report.
+            // Instantiate the Evento with the provided ID instead of using the
+            // mapper which expects all fields to be present.
+            com.cultureclub.cclub.entity.Evento evento = new com.cultureclub.cclub.entity.Evento();
+            evento.setIdEvento(eventoDto.getIdEventoReportado());
+            r.setEventoReportado(evento);
             reporte = r;
         } else {
             throw new IllegalArgumentException("Unsupported ReporteDTO type: " + dto.getClass().getName());


### PR DESCRIPTION
## Summary
- construct a minimal `Evento` when converting a `ReporteEventoDTO`

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685dab86093083248e02e9c48f6f384e