### PR TITLE
Implement follower query for user followings

### DIFF
--- a/src/main/java/com/cultureclub/cclub/repository/UsuarioRepository.java
+++ b/src/main/java/com/cultureclub/cclub/repository/UsuarioRepository.java
@@ -24,4 +24,6 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
     public List<Usuario> findBySeguidos_IdUsuario(Long usuarioId);
 
+    public List<Usuario> findBySeguidores_IdUsuario(Long idUsuario);
+
 }

--- a/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
+++ b/src/main/java/com/cultureclub/cclub/service/Impl/UsuarioServiceImpl.java
@@ -227,7 +227,7 @@ public class UsuarioServiceImpl implements UsuarioService {
 
     @Override
     public List<Usuario> getSeguidosByUsuario(Long usuarioId) {
-        List<Usuario> seguidos = usuarioRepository.findBySeguidos_IdUsuario(usuarioId);
+        List<Usuario> seguidos = usuarioRepository.findBySeguidores_IdUsuario(usuarioId);
         if (seguidos.isEmpty()) {
             throw new IllegalArgumentException("No se encontraron seguidos para el usuario con ID: " + usuarioId);
         }


### PR DESCRIPTION
## Summary
- create `findBySeguidores_IdUsuario` repository method
- use it in `UsuarioServiceImpl.getSeguidosByUsuario`

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dabc1d8c8832484e692682242da78